### PR TITLE
allowScriptAccess

### DIFF
--- a/jquery.webcam.js
+++ b/jquery.webcam.js
@@ -44,7 +44,7 @@
 	    }
 	}
 
-	var source = '<object id="XwebcamXobjectX" type="application/x-shockwave-flash" data="'+webcam.swffile+'" width="'+webcam.width+'" height="'+webcam.height+'"><param name="movie" value="'+webcam.swffile+'" /><param name="FlashVars" value="mode='+webcam.mode+'&amp;quality='+webcam.quality+'" /></object>';
+	var source = '<object id="XwebcamXobjectX" type="application/x-shockwave-flash" data="'+webcam.swffile+'" width="'+webcam.width+'" height="'+webcam.height+'"><param name="movie" value="'+webcam.swffile+'" /><param name="FlashVars" value="mode='+webcam.mode+'&amp;quality='+webcam.quality+'" /><param name="allowScriptAccess" value="always" /></object>';
 
 	if (null !== webcam.extern) {
 	    $(webcam.extern)[webcam.append ? "append" : "html"](source);


### PR DESCRIPTION
Although the security settings are set up in the actionscript to allow script access from any domain, I found that adding the allowScriptAccess param to the flash object was the only way I was able to use the flash-javascript interface.
Prior to adding it, the `capture` method was never accessible from javascript, and the `_register` function would die before actually defining the public api and calling the load callback.

I might be missing something, but wanted to suggest the fix.
