### PR TITLE
Add pauseCamera and resumeCamera to allow camera pausing and resuming

### DIFF
--- a/jquery.webcam.js
+++ b/jquery.webcam.js
@@ -75,7 +75,16 @@
 			return cam.getCameraList();
 		    } catch(e) {}
 		}
-
+		webcam.pauseCamera = function() {
+		    try {
+			return cam.pauseCamera();
+		    } catch(e) {}
+		}		
+		webcam.resumeCamera = function() {
+		    try {
+			return cam.resumeCamera();
+		    } catch(e) {}
+		}
 		webcam.onLoad();
 	    } else if (0 == run) {
 		webcam.debug("error", "Flash movie not yet registered!");

--- a/src/jscam.as
+++ b/src/jscam.as
@@ -74,6 +74,9 @@ class JSCam {
 
 			ExternalInterface.addCallback("save", null, save);
 
+			ExternalInterface.addCallback("pauseCamera", null, pauseCamera);
+			ExternalInterface.addCallback("resumeCamera", null, resumeCamera);
+
 			ExternalInterface.addCallback("setCamera", null, setCamera);
 			ExternalInterface.addCallback("getCameraList", null, getCameraList);
 
@@ -86,6 +89,13 @@ class JSCam {
 			ExternalInterface.call('webcam.debug', "error", "No camera was detected.");
 		}
 	}
+	public static function pauseCamera():Void {
+		_root.video.attachVideo(null);
+	}
+	public static function resumeCamera():Void {
+		_root.video.attachVideo(camera);
+	}
+
 
 	public static function capture(time:Number):Boolean {
 


### PR DESCRIPTION
Hi,

I added pauseCamera and resumeCamera functions, to allow pausing and resuming the stream, based on how JPEGcam does stop and resume back the stream:
http://code.google.com/p/jpegcam/source/browse/trunk/src/Webcam.as

When paused, you can capture as usual to fetch the paused image. I'm testing this to let the user preview the image that will be uploaded before it is uploaded, as I did previously with JPEGcam, and it seems to work fine.
