### PR TITLE
Functions called with setTimeout doesn't receive parameters in Internet Explorer

### DIFF
--- a/jquery.webcam.js
+++ b/jquery.webcam.js
@@ -48,8 +48,8 @@
 	    this[webcam.append ? "append" : "html"](source);
 	}
 
-	(_register = function(run) {
-
+	var run = 3;
+	(_register = function() {
 	    var cam = document.getElementById('XwebcamXobjectX');
 
 	    if (cam.capture !== undefined) {
@@ -81,9 +81,10 @@
 		webcam.debug("error", "Flash movie not yet registered!");
 	    } else {
 		/* Flash interface not ready yet */
-		window.setTimeout(_register, 1000 * (4 - run), run - 1);
+		run--;
+		window.setTimeout(_register, 1000 * (4 - run));
 	    }
-	})(3);
+	})();
     }
 
 })(jQuery);


### PR DESCRIPTION
In Internet Explorer the function `_register` receives `undefined` and will not stop trying to register when the flash movie is not loaded.
